### PR TITLE
Fixed bugs in core game loop

### DIFF
--- a/src/game/events.ts
+++ b/src/game/events.ts
@@ -1,78 +1,110 @@
-import { GameState, GameEvent } from './types';
+import { GameState, GameEvent, ActivityType } from './types';
 import { emptyResources } from './constants';
 
-const waterEvent = (gameState: GameState): GameEvent => {
+const peopleAllocated = (activity: ActivityType, gameState: GameState): number =>
+  gameState.activityAllocations[activity];
+
+const noPeopleAllocated = (activity: ActivityType, gameState: GameState): boolean =>
+  peopleAllocated(activity, gameState) <= 0;
+
+const determineWaterEvents = (gameState: GameState): GameEvent[] => {
+  if (noPeopleAllocated('collect_water', gameState)) {
+    return [];
+  }
+
   const luck = Math.random();
   const people = gameState.activityAllocations.collect_water;
-  const water = (3 + luck) * people;
-  return {
-    message: `Retrieved water, stored ${water} units`,
-    resourceDeltas: { ...emptyResources, water },
-  };
+  const water = Math.round((3 + luck) * people);
+  return [
+    {
+      message: `Retrieved water, stored ${water} units`,
+      resourceDeltas: { ...emptyResources, water },
+    },
+  ];
 };
 
-const forageEvent = (gameState: GameState): GameEvent => {
+const determineForageEvents = (gameState: GameState): GameEvent[] => {
+  if (noPeopleAllocated('gather_food', gameState)) {
+    return [];
+  }
+
   const successProbability = 0.9;
   const luck = Math.random();
   const people = gameState.activityAllocations.gather_food;
   const failed = luck > successProbability;
   if (failed) {
-    return {
-      message: 'No food was found, hopefully we need less than we thought',
-      resourceDeltas: { ...emptyResources },
-    };
+    return [
+      {
+        message: 'No food was found, hopefully we need less than we thought',
+        resourceDeltas: { ...emptyResources },
+      },
+    ];
   }
-  const food = (1.5 + luck) * people;
-  return {
-    message: `Gathered some berries, stored ${food} units`,
-    resourceDeltas: { ...emptyResources, food },
-  };
+  const food = Math.round((1.5 + luck) * people);
+  return [
+    {
+      message: `Gathered some berries, stored ${food} units`,
+      resourceDeltas: { ...emptyResources, food },
+    },
+  ];
 };
 
-const huntEvent = (gameState: GameState): GameEvent => {
+const determineHuntEvents = (gameState: GameState): GameEvent[] => {
+  if (noPeopleAllocated('hunt', gameState)) {
+    return [];
+  }
+
   const luck = Math.random();
   const people = gameState.activityAllocations.hunt;
   const successProbability = 0.4;
-  const failed = people <= 0 || luck > successProbability;
+  const failed = luck > successProbability;
   if (failed) {
-    return {
-      message: 'The hunt failed',
-      resourceDeltas: { ...emptyResources },
-    };
+    return [
+      {
+        message: 'The hunt failed',
+        resourceDeltas: { ...emptyResources },
+      },
+    ];
   }
-  const food = (10 + luck * 10) * people;
-  return {
-    message: `Caught some meat, stored ${food} units`,
-    resourceDeltas: { ...emptyResources, food },
-  };
+  const food = Math.round((10 + luck * 10) * people);
+  return [
+    {
+      message: `Caught some meat, stored ${food} units`,
+      resourceDeltas: { ...emptyResources, food },
+    },
+  ];
 };
 
-const lumberEvent = (gameState: GameState): GameEvent => {
+const determineLumberEvents = (gameState: GameState): GameEvent[] => {
+  if (noPeopleAllocated('gather_lumber', gameState)) {
+    return [];
+  }
   const luck = Math.random();
-  const people = gameState.activityAllocations.gather_lumber;
-  const wood = (2 + luck * 2) * people;
-  return {
-    message: `Retrieved lumber, stored ${wood} units`,
-    resourceDeltas: { ...emptyResources, wood },
-  };
+  const wood = Math.round((2 + luck * 2) * peopleAllocated('gather_lumber', gameState));
+  return [
+    {
+      message: `Retrieved lumber, stored ${wood} units`,
+      resourceDeltas: { ...emptyResources, wood },
+    },
+  ];
 };
 
-export const consumeEvent = (gameState: GameState): GameEvent => {
-  const people = gameState.resources.stored;
-  return {
-    message: `Consumed food and water for ${people} people`,
-    resourceDeltas: { ...emptyResources, food: -people, water: -people },
-  };
+export const determineConsumeEvents = (gameState: GameState): GameEvent[] => {
+  const people = gameState.resources.stored.people;
+  return [
+    {
+      message: `Consumed food and water for ${people} people`,
+      resourceDeltas: { ...emptyResources, food: -people, water: -people },
+    },
+  ];
 };
 
 export const calculateDaysEvents = (gameState: GameState): GameEvent[] => {
-  const result = [];
-
-  result.push(waterEvent(gameState));
-  result.push(forageEvent(gameState));
-  result.push(huntEvent(gameState));
-  result.push(lumberEvent(gameState));
-  result.push(consumeEvent(gameState));
-
-  return result;
+  return [
+    ...determineWaterEvents(gameState),
+    ...determineForageEvents(gameState),
+    ...determineHuntEvents(gameState),
+    ...determineLumberEvents(gameState),
+    ...determineConsumeEvents(gameState),
+  ];
 };

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { calculateDaysEvents, emptyActivities, updatedResources, GameState, SetAllocationPayload } from '../game';
+import { calculateDaysEvents, updatedResources, GameState, SetAllocationPayload } from '../game';
 
 const initialState: GameState = {
   exploration: {
@@ -57,10 +57,11 @@ const gameStateSlice = createSlice({
       const { food, water } = state.resources.stored;
       state.progress.failed = food < 0 || water < 0;
 
-      // reset state for start of day
-      state.activityAllocations = {
-        ...emptyActivities,
-      };
+      // TODO: validate allocations and replace with corrected versions
+      // - resource nodes may run out
+      // - people count may change
+      // - projects may complete
+      //state.activityAllocations = validatedAllocations(state);
     },
   },
 });


### PR DESCRIPTION
- trigger events for activities with allocated people only to cut down on event noise
- don't clear activity allocations on day reset since it's time consuming to change them currently and you'll usually want to tweak from day to day
- round the resource deltas to round numbers to simplify display code
- fixed bug with NaN on display (caused by passing `gameState.resources.stored` instead of `gameState.resources.stored.people` in `determineConsumeEvents` function )